### PR TITLE
Allow multiple domain names in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,35 @@ Have a look at `config.ini.example` for the sample configuration
 
 ```
 [DEFAULT]
-## Domain used as alias domain. I recommend purchasing a unrelated domain and add it to your
-## Mailcow installation. Alternatively you can just use your main domain.
-RELAY_DOMAIN = privacycow.com 
-# The address mails go to.
+# The default domain used as an alias domain. I recommend purchasing an
+# unrelated domain and adding it to your Mailcow installation. Alternatively
+# you can just use your main domain.
+RELAY_DOMAIN = example.com 
+# The address emails will go to if a GOTO is not defined in the
+# [$RELAY_DOMAIN] settings section.
 GOTO = user@example.com
-## Those two settings should be self explanatory
+# These two settings should be self explanatory and will be used if
+# there is not a MAILCOW_API_KEY or MAILCOW_INSTANCE setting in the
+# [$RELAY_DOMAIN] settings section.
 MAILCOW_API_KEY = api_key
 MAILCOW_INSTANCE = https://mail.example.com
+
+[example.com]
+# The settings to be used when example.com is RELAY_DOMAIN.  RELAY_DOMAIN
+# in the [DEFAULT] section is defining this section as the default.
+# All three parameters are optional here as if they are not defined
+# the setting from DEFAULT will be used instead.
+GOTO = another@example.com
+MAILCOW_API_KEY = another_api_key
+MAILCOW_INSTANCE = https://mail.example.com
+
+[example.org]
+# These settings can be used by calling privacycow like this:
+# RELAY_DOMAIN=example.org privacycow list
+GOTO = user@example.org
+# Note we have chosen not to define MAILCOW_API_KEY and
+# MAILCOW_INSTANCE here so the values in [DEFAULT] will be used instead.
+
 
 ```
 

--- a/privacycow/config.ini.example
+++ b/privacycow/config.ini.example
@@ -3,3 +3,6 @@ RELAY_DOMAIN = privacycow.com
 GOTO = user@example.com
 MAILCOW_API_KEY = api_key
 MAILCOW_INSTANCE = https://mail.example.com
+
+[privacycow.com]
+GOTO = alternative@example.com

--- a/privacycow/privacycow.py
+++ b/privacycow/privacycow.py
@@ -30,10 +30,27 @@ else:
     config = read_config(config_path + "config.ini")
     click.echo("Privacycow ran for the first time.\nMake sure you check your config file at %s" % config_path + "config.ini")
 
-RELAY_DOMAIN = env.get("RELAY_DOMAIN", config['DEFAULT']['RELAY_DOMAIN'])
-MAILCOW_API_KEY = env.get("MAILCOW_API_KEY", config['DEFAULT']['MAILCOW_API_KEY'])
-MAILCOW_INSTANCE = env.get("MAILCOW_INSTANCE", config['DEFAULT']['MAILCOW_INSTANCE'])
-GOTO = env.get("GOTO", config['DEFAULT']['GOTO'])
+RELAY_DOMAIN = env.get('RELAY_DOMAIN', config['DEFAULT']['RELAY_DOMAIN'])
+MAILCOW_API_KEY = env.get('MAILCOW_API_KEY')
+if not MAILCOW_API_KEY:
+    if RELAY_DOMAIN in config and 'MAILCOW_API_KEY' in config[RELAY_DOMAIN]:
+        MAILCOW_API_KEY = config[RELAY_DOMAIN]['MAILCOW_API_KEY']
+    else:
+        MAILCOW_API_KEY = config['DEFAULT']['MAILCOW_API_KEY']
+MAILCOW_INSTANCE = env.get("MAILCOW_INSTANCE")
+if not MAILCOW_INSTANCE:
+    if RELAY_DOMAIN in config and 'MAILCOW_INSTANCE' in config[RELAY_DOMAIN]:
+        MAILCOW_INSTANCE = config[RELAY_DOMAIN]['MAILCOW_INSTANCE']
+    else:
+        MAILCOW_INSTANCE = config['DEFAULT']['MAILCOW_INSTANCE']
+GOTO = env.get('GOTO')
+if not GOTO:
+    if RELAY_DOMAIN in config and 'GOTO' in config[RELAY_DOMAIN]:
+        GOTO = config[RELAY_DOMAIN]['GOTO']
+    else:
+        GOTO = config['DEFAULT']['GOTO']
+
+
 VOWELS = "aeiou"
 CONSONANTS = "bcdfghjklmnpqrstvwxyz"
 
@@ -201,5 +218,5 @@ def allowed_gai_family():
 urllib3_cn.allowed_gai_family = allowed_gai_family
 
 ## Uncomment if you want to use it without installing it
-# if __name__ == '__main__':
-#     cli()
+#if __name__ == '__main__':
+#    cli()


### PR DESCRIPTION
This PR implements the option to include multiple relay domains in the config file.