### PR TITLE
Allow aliases to be altered to collect spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Have a look at `config.ini.example` for the sample configuration
 # The default domain used as an alias domain. I recommend purchasing an
 # unrelated domain and adding it to your Mailcow installation. Alternatively
 # you can just use your main domain.
-RELAY_DOMAIN = example.com 
+RELAY_DOMAIN = example.com
 # The address emails will go to if a GOTO is not defined in the
 # [$RELAY_DOMAIN] settings section.
 GOTO = user@example.com
@@ -80,7 +80,7 @@ GOTO = user@example.org
 
 ## Usage
 ```
-➜  privacycow     
+➜  privacycow
 Usage: privacycow [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -91,8 +91,9 @@ Commands:
   add      Create a new random alias.
   delete   Delete a alias.
   disable  Disable a alias, done by setting the "Silently Discard" option.
-  enable   Enable a alias, which disables "Silently Discard".
+  enable   Enable a alias, stop discarding email or collecting spam.
   list     Lists all aliases with the configured privacy domain.
+  spam     Mark all email sent to an alias as spam.
 
 ```
 
@@ -103,22 +104,37 @@ Commands:
 ➜  privacycow add -c "terrible place"
 Success! The following Alias has been created:
 Alias ID:       29
-Alias Email:    5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@privacycow.com
+Alias Email:    5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@example.com
 Alias Comment:  terrible place
 
 
-➜  privacycow disable 29             
+➜  privacycow disable 29
 Success! The following Alias disabled:
 Alias ID:       29
 Alias Email:    5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@privacyfwd.ch
 
 
 
-➜  privacycow list      
-ID                        Alias                           Comment       Active 
+➜  privacycow list
+ID                        Alias                           Comment       Status
 ===============================================================================
-22   pQf6qmgMxpa8C.c1Q3sdpDZarqf4ggCe2@privacycow.com  bad actor        Active 
-28   mX4WjTjHcJwa96Vk.xEKpPKbgArysoWvg@privacycow.com  test             Active 
-29   5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@privacycow.com  terrible place   Discard
+22   pQf6qmgMxpa8C.c1Q3sdpDZarqf4ggCe2@example.com  bad actor        Active
+28   mX4WjTjHcJwa96Vk.xEKpPKbgArysoWvg@example.com  test             Active
+29   5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@example.com  terrible place   Discard
 
-``` 
+
+➜  privacycow spam 28
+Success! The following Alias now collects spam:
+Alias ID:       28
+Alias Email:    mX4WjTjHcJwa96Vk.xEKpPKbgArysoWvg@example.com
+
+
+➜  privacycow list
+ID                        Alias                           Comment       Status
+===============================================================================
+22   pQf6qmgMxpa8C.c1Q3sdpDZarqf4ggCe2@example.com  bad actor        Active
+28   mX4WjTjHcJwa96Vk.xEKpPKbgArysoWvg@example.com  spam (test)      Spam
+29   5b25SxYx9J46lJjk.YVuONdYUUA3ekAgU@example.com  terrible place   Discard
+
+
+```

--- a/privacycow/privacycow.py
+++ b/privacycow/privacycow.py
@@ -166,7 +166,6 @@ def spam(ctx, alias_id):
         r.raise_for_status()
     except requests.exceptions.HTTPError as err:
         raise SystemExit(err)
-    print(r.json())
 
     API_ENDPOINT = "/api/v1/edit/alias"
     data = {

--- a/privacycow/privacycow.py
+++ b/privacycow/privacycow.py
@@ -71,6 +71,7 @@ def list(ctx):
     """Lists all aliases with the configured privacy domain."""
     API_ENDPOINT = "/api/v1/get/alias/all"
     headers = {'X-API-Key': MAILCOW_API_KEY}
+    possible_domains = [RELAY_DOMAIN] + [ccc for ccc in config.sections() if ccc != RELAY_DOMAIN]
 
     try:
         r = requests.get(MAILCOW_INSTANCE + API_ENDPOINT, headers=headers, )
@@ -81,12 +82,14 @@ def list(ctx):
     table = texttable.Texttable()
     table.set_deco(texttable.Texttable.HEADER)
     table.set_max_width(0)
-    table.header(["ID", "Alias", "Comment", "Active"])
+    table.header(["ID", "Alias", "Comment", "Status"])
 
     for i in r.json():
-        if i["domain"] == RELAY_DOMAIN:
+        if i["domain"] in possible_domains:
             if i["goto"] == "null@localhost":
                 active = "Discard"
+            elif i["goto"] == "spam@localhost":
+                active = "Spam"
             else:
                 active = "Active"
 
@@ -151,11 +154,49 @@ def disable(ctx, alias_id):
 
 @cli.command()
 @click.argument('alias_id')
+@click.pass_context
+def spam(ctx, alias_id):
+    """Mark all email sent to an alias as spam."""
+
+    API_ENDPOINT = f"/api/v1/get/alias/{alias_id}"
+    headers = {'X-API-Key': MAILCOW_API_KEY}
+
+    try:
+        r = requests.get(MAILCOW_INSTANCE + API_ENDPOINT, headers=headers, )
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise SystemExit(err)
+    print(r.json())
+
+    API_ENDPOINT = "/api/v1/edit/alias"
+    data = {
+        "items": [alias_id],
+        "attr": {
+            "goto_spam": "1",
+            "public_comment": (
+                f'spam ({r.json()["public_comment"]})')}}
+
+    try:
+        r = requests.post(MAILCOW_INSTANCE + API_ENDPOINT, headers=headers, json=data)
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise SystemExit(err)
+
+    data = r.json()
+
+    click.echo("Success! The following Alias now collects spam:")
+    click.echo("Alias ID:       %s" % data[0]["log"][3]["id"][0])
+    click.echo("Alias Email:    %s" % data[0]["msg"][1])
+    click.echo("Alias Comment:  %s" % data[0]["log"][3]["public_comment"])
+
+
+@cli.command()
+@click.argument('alias_id')
 @click.option('-g', '--goto', default=GOTO,
               help='Goto address "mail@example.com". If no option is passed, GOTO env variable or config.ini will be used.')
 @click.pass_context
 def enable(ctx, alias_id, goto):
-    """Enable a alias, which disables "Silently Discard". """
+    """Enable a alias, stop discarding email or collecting spam. """
     API_ENDPOINT = "/api/v1/edit/alias"
     headers = {'X-API-Key': MAILCOW_API_KEY}
 


### PR DESCRIPTION
A spam function has been added that allows the alias to be changed to collect spam.  

Any email that is sent to the alias in the future will be marked as spam in the future.

To remove the "spam" setting simply use the existing enable function that restores the GOTO address.